### PR TITLE
Custom Scheduling Options (including gang-scheduling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ kube-openmpi provides mainly two things:
 - [Use your own custom docker image](#use-your-own-custom-docker-image)
 - [Inject your code to your containers from Github](#inject-your-code-to-your-containers-from-github)
 - [Run kube-openmpi cluster as non-root user](#run-kube-openmpi-cluster-as-non-root-user)
+- [How to use gang-scheduling (i.e. schedule a group of pods at once)](#how-to-user-gang-scheduling-i-e-schedule-a-group-of-pods-at-once)
 - [Release Notes](#release-notes)
 
 
@@ -174,6 +175,25 @@ This creates ubuntu based image, cuda8(cudnn7) image and cuda9(cudnn7) image.
 
 And then, set the `image` in your `values.yaml` and set your uid/gid to `runAsUser`/`fsGroup` as the previous section.
 
+# How to use gang-scheduling (i.e. schedule a group of pods at once)
+As stated kubeflow/tf-operator#165 , spawning multiple kube-openmpi cluster causes deadlock.  To prevent it,  you might want `gang-scheduling` (i.e schedule multiple pods all together) in kubernetes.  Currently, [kubernetes-incubator/kube-arbitrator](https://github.com/kubernetes-incubator/kube-arbitrator) support it by using `kube-batchd` scheduler and `PodDisruptionBudget`.
+
+Please follow the steps:
+
+1. [deploy `kube-batchd` scheduler](https://github.com/kubernetes-incubator/kube-arbitrator/blob/master/doc/usage/batchd_tutorial.md)
+
+2. Edit `mpiWorkers.customScheduling` section in your `values.yaml` like this.
+
+   ```
+   mpiWorkers:
+     customScheduling:
+       enabled: true
+       schedulerName: <your_kube-batchd_scheduler_name>
+       podDisruptionBudget:
+         enabled: true
+   ```
+
+3. Deploy your kube-openmpi cluster.
 
 ## Release Notes
 ### __0.5.1__

--- a/chart/templates/mpi-cluster.yaml
+++ b/chart/templates/mpi-cluster.yaml
@@ -1,3 +1,19 @@
+{{ if and .Values.mpiWorkers.customScheduling.enabled .Values.mpiWorkers.customScheduling.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-worker-pdb
+spec:
+  minAvailable: {{ .Values.mpiWorkers.num }}
+  selector:
+    matchLabels:
+      app: {{ template "..name" . }}
+      chart: {{ template "..chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      role: worker
+---
+{{ end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -28,6 +44,9 @@ spec:
         heritage: {{ .Release.Service }}
         role: worker
     spec:
+{{- if .Values.mpiWorkers.customScheduling.enabled }}
+      schedulerName: {{.Values.mpiWorkers.customScheduling.schedulerName}}
+{{- end }}
       securityContext:
 {{ toYaml .Values.mpiWorkers.securityContext | indent 8 }}
       volumes:
@@ -118,6 +137,9 @@ metadata:
 spec:
   hostname: {{ .Release.Name }}-master
   subdomain: {{ .Release.Name }}
+{{- if .Values.mpiMaster.customScheduling.enabled }}
+  schedulerName: {{.Values.mpiMaster.customScheduling.schedulerName}}
+{{- end }}
   securityContext:
 {{ toYaml .Values.mpiMaster.securityContext | indent 8 }}
   volumes:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -33,6 +33,9 @@ mpiMaster:
   securityContext:
   #   runAsUser: 1000
   #   fsGroup: 1000
+  customScheduling:
+    enabled: false
+    schedulerName: ""
   resources:
     # limits:
     #  cpu: 100m
@@ -51,6 +54,11 @@ mpiWorkers:
   securityContext:
   #   runAsUser: 1000
   #   fsGroup: 1000
+  customScheduling:
+    enabled: false
+    schedulerName: ""
+    podDisruptionBudget:
+      enabled: false
   resources:
     # limits:
     #  cpu: 100m

--- a/values.yaml
+++ b/values.yaml
@@ -37,6 +37,11 @@ mpiWorkers:
   # securityContext:
   #   runAsUser: 1000
   #   fsGroup: 1000
+  # customScheduling:
+  #   enabled: true
+  #   schedulerName: kube-batchd
+  #   podDisruptionBudget:
+  #     enabled: true
   resources:
     # limits:
     #  cpu: 100m


### PR DESCRIPTION
- introduced 
  - custom scheduler option for both mpi master and workers
  - pod disruption budget for mpi workers if enabled

Consequently, we can `gang-schedule`  mpi workers via [kube-batchd in kube-arbitrator](https://github.com/kubernetes-incubator/kube-arbitrator/blob/master/doc/usage/batchd_tutorial.md)

it solves #7 