### PR TITLE
support oneShot style job with auto workers down feature.

### DIFF
--- a/chainermn-example/values.yaml
+++ b/chainermn-example/values.yaml
@@ -8,6 +8,15 @@ image:
 mpiMaster:
   autoUpdateHostfile:
     enabled: true
+  oneShot:
+    enabled: true
+    # This will scale workers down to 0 when command completed successfully.
+    autoScaleDownWorkers: true
+    command: |
+      mpiexec --allow-run-as-root \
+        --hostfile /kube-openmpi/generated/hostfile \
+        --display-map -n 2 -npernode 1 \
+        python3 /chainermn-examples/mnist/train_mnist.py -g
   # resources:
   #   limits:
   #     cpu: 100m

--- a/chart/templates/mpi-cluster.yaml
+++ b/chart/templates/mpi-cluster.yaml
@@ -157,6 +157,7 @@ metadata:
     role: master
     {{if .Values.networkPolicy.enabled }}allow_from_external: "true"{{ end }}
 spec:
+  restartPolicy: OnFailure
   hostname: {{ .Release.Name }}-master
   subdomain: {{ .Release.Name }}
 {{- if .Values.mpiMaster.customScheduling.enabled }}
@@ -169,6 +170,8 @@ spec:
 {{ toYaml .Values.image.pullSecrets | indent 2 }}
 {{- end }}
   volumes:
+  - name: kube-openmpi-guillotine
+    emptyDir: {}
   - name: kube-openmpi-hostfile-dir
     emptyDir: {}
 {{ if .Values.mpiMaster.autoUpdateHostfile.enabled }}
@@ -261,7 +264,19 @@ spec:
     env:
     - name: HOSTFILE
       value: /kube-openmpi/generated/hostfile
+    - name: GUILLOTINE
+      value: /kube-openmpi/guillotine
+    {{- if .Values.mpiMaster.oneShot.enabled }}
+    - name: ONE_SHOT
+      value: "true"
+    command:
+    - /init.sh
+    - |
+{{ .Values.mpiMaster.oneShot.command | indent 6 }}
+    {{- end }}
     volumeMounts:
+    - name: kube-openmpi-guillotine
+      mountPath: /kube-openmpi/guillotine
     - name: kube-openmpi-ssh-key
       mountPath: /ssh-key/openmpi
     - name: kube-openmpi-hostfile-dir
@@ -278,6 +293,34 @@ spec:
 {{ end }}
     resources:
 {{ toYaml .Values.mpiMaster.resources | indent 10 }}
+{{ if .Values.mpiMaster.oneShot.enabled }}
+{{ if .Values.mpiMaster.oneShot.autoScaleDownWorkers }}
+  - name: worker-auto-downing
+    image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
+    imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
+    command:
+    - sh
+    - -c
+    - |
+      while [ ! -e $GUILLOTINE/execute ];
+      do
+        sleep 5;
+        echo -n .
+      done
+      echo
+      return_code=$(cat $GUILLOTINE/execute)
+      if [ "$return_code" = 0 ]; then
+        kubectl -n {{ .Release.Namespace }} scale statefulsets {{ .Release.Name }}-worker --replicas=0
+      fi
+      echo Done.
+    env:
+    - name: GUILLOTINE
+      value: /kube-openmpi/guillotine
+    volumeMounts:
+    - name: kube-openmpi-guillotine
+      mountPath: /kube-openmpi/guillotine
+{{ end }}
+{{ end }}
 {{ if .Values.mpiMaster.autoUpdateHostfile.enabled }}
   - name: hostfile-updater
     image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
@@ -286,7 +329,7 @@ spec:
     - sh
     - -c
     - |
-      while true;
+      while [ ! -e $GUILLOTINE/execute ];
       do
         /kube-openmpi/utils/gen_hostfile.sh $HOSTFILE_DIR/hostfile 1
         if [ -e /kube-openmpi/hostfile-updater-params/update_every ]; then
@@ -294,12 +337,17 @@ spec:
         fi
         sleep ${SLEEP:-15}
       done
+      echo Done.
     env:
     - name: HOSTFILE_DIR
       value: /kube-openmpi/generated
+    - name: GUILLOTINE
+      value: /kube-openmpi/guillotine
     volumeMounts:
     - name: kube-openmpi-hostfile-dir
       mountPath: /kube-openmpi/generated
+    - name: kube-openmpi-guillotine
+      mountPath: /kube-openmpi/guillotine
     - name: kube-openmpi-utils
       mountPath: /kube-openmpi/utils
     - name: kube-openmpi-hostfile-updater-params

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -35,6 +35,14 @@ mpiMaster:
   securityContext:
   #   runAsUser: 1000
   #   fsGroup: 1000
+  oneShot:
+    enabled: false
+    autoScaleDownWorkers: true
+    command: |
+      mpiexec --allow-run-as-root \
+        --hostfile /kube-openmpi/generated/hostfile \
+        --display-map -n 4 -npernode 1 \
+        sh -c 'echo $(hostname):hello'
   customScheduling:
     enabled: false
     schedulerName: ""

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -62,4 +62,4 @@ RUN if [ "$WITH_CUDA" = "true" ]; then \
 EXPOSE 2022
 
 # sshd can be run either by root or $SSH_USER
-CMD ["/start_sshd.sh"]
+CMD ["/init.sh"]

--- a/image/rootfs/init.sh
+++ b/image/rootfs/init.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+/start_sshd.sh >/.sshd/user_keys/sshd.log 2>&1 &
+
+# magic sleep for waiting sshd being up
+sleep 5
+echo "sshd started pid=$(ps auwx |grep [s]sh |  awk '{print $2}')"
+
+if [ ! "z$ONE_SHOT" = "z" ]; then
+  bash -c "$*"
+  return_code=$?
+else
+  sleep infinity
+  return_code=$?
+fi
+echo -n "$return_code" > /dev/termination-log
+echo -n "$return_code" > $GUILLOTINE/execute
+ls -l $GUILLOTINE/execute
+exit $return_code

--- a/values.yaml
+++ b/values.yaml
@@ -18,6 +18,15 @@ mpiMaster:
   # securityContext:
   #   runAsUser: 1000
   #   fsGroup: 1000
+  # oneShot:
+  #   enabled: true
+  #   # This will scale workers down to 0 when command completed successfully.
+  #   autoScaleDownWorkers: true
+  #   command: |
+  #     mpiexec --allow-run-as-root \
+  #       --hostfile /kube-openmpi/generated/hostfile \
+  #       --display-map -n 4 -npernode 1 \
+  #       sh -c 'echo $(hostname):hello'
   resources:
     # limits:
     #  cpu: 100m


### PR DESCRIPTION
- support `oneShot` mode
  - this automatically run `command` in `mpi-master`
  - if `autoScaleDownWorkers` was enabled and the command successfully completed, `mpi-master` scale down workers to `0`.